### PR TITLE
Add user name preference

### DIFF
--- a/backend/agent/api.py
+++ b/backend/agent/api.py
@@ -40,6 +40,7 @@ class AgentStartRequest(BaseModel):
     stream: Optional[bool] = True
     enable_context_manager: Optional[bool] = False
     agent_id: Optional[str] = None  # Custom agent to use
+    user_name: Optional[str] = None
 
 class InitiateAgentResponse(BaseModel):
     thread_id: str
@@ -490,6 +491,7 @@ async def start_agent(
         is_agent_builder=is_agent_builder,
         target_agent_id=target_agent_id,
         request_id=request_id,
+        user_name=body.user_name,
     )
 
     return {"agent_run_id": agent_run_id, "status": "running"}
@@ -1106,6 +1108,7 @@ async def initiate_agent_with_files(
             is_agent_builder=is_agent_builder,
             target_agent_id=target_agent_id,
             request_id=request_id,
+            user_name=body.user_name,
         )
 
         return {"thread_id": thread_id, "agent_run_id": agent_run_id}

--- a/backend/agent/prompt.py
+++ b/backend/agent/prompt.py
@@ -657,8 +657,10 @@ For casual conversation and social interactions:
   """
 
 
-def get_system_prompt():
-    '''
-    Returns the system prompt
-    '''
-    return SYSTEM_PROMPT 
+def get_system_prompt(user_name: str = "Pookie"):
+    """Return the system prompt personalized with the user's name."""
+    intro = (
+        f"The user interacting with you is named {user_name}. "
+        f"Always refer to them as {user_name}."
+    )
+    return intro + "\n\n" + SYSTEM_PROMPT

--- a/backend/agent/run.py
+++ b/backend/agent/run.py
@@ -53,7 +53,8 @@ async def run_agent(
     agent_config: Optional[dict] = None,    
     trace: Optional[StatefulTraceClient] = None,
     is_agent_builder: Optional[bool] = False,
-    target_agent_id: Optional[str] = None
+    target_agent_id: Optional[str] = None,
+    user_name: Optional[str] = None,
 ):
     """Run the development agent with specified configuration."""
     logger.info(f"🚀 Starting agent with model: {model_name}")
@@ -213,7 +214,7 @@ async def run_agent(
         default_system_content = get_gemini_system_prompt()
     else:
         # Use the original prompt - the LLM can only use tools that are registered
-        default_system_content = get_system_prompt()
+        default_system_content = get_system_prompt(user_name or "Pookie")
         
     # Add sample response for non-anthropic models
     if "anthropic" not in model_name.lower():

--- a/backend/run_agent_background.py
+++ b/backend/run_agent_background.py
@@ -65,6 +65,7 @@ async def run_agent_background(
     is_agent_builder: Optional[bool] = False,
     target_agent_id: Optional[str] = None,
     request_id: Optional[str] = None,
+    user_name: Optional[str] = None,
 ):
     """Run the agent in the background using Redis for state."""
     structlog.contextvars.clear_contextvars()
@@ -304,7 +305,8 @@ async def run_agent_background(
             agent_config=agent_config,
             trace=trace,
             is_agent_builder=is_agent_builder,
-            target_agent_id=target_agent_id
+            target_agent_id=target_agent_id,
+            user_name=user_name,
         )
 
         final_status = "running"

--- a/frontend/src/app/(dashboard)/(personalAccount)/settings/page.tsx
+++ b/frontend/src/app/(dashboard)/(personalAccount)/settings/page.tsx
@@ -1,4 +1,5 @@
 import EditPersonalAccountName from '@/components/basejump/edit-personal-account-name';
+import EditUserName from '@/components/basejump/edit-user-name';
 import { createClient } from '@/lib/supabase/server';
 
 export default async function PersonalAccountSettingsPage() {
@@ -6,9 +7,12 @@ export default async function PersonalAccountSettingsPage() {
   const { data: personalAccount } = await supabaseClient.rpc(
     'get_personal_account',
   );
+  const { data } = await supabaseClient.auth.getUser();
+  const currentName = data.user?.user_metadata?.name || 'Pookie';
 
   return (
-    <div>
+    <div className="space-y-6">
+      <EditUserName currentName={currentName} />
       <EditPersonalAccountName account={personalAccount} />
     </div>
   );

--- a/frontend/src/app/(dashboard)/agents/_components/agent-builder-chat.tsx
+++ b/frontend/src/app/(dashboard)/agents/_components/agent-builder-chat.tsx
@@ -16,6 +16,7 @@ import { EditableText } from '@/components/ui/editable';
 import { Badge } from '@/components/ui/badge';
 import { Check, Clock } from 'lucide-react';
 import { BillingError } from '@/lib/api';
+import { getStoredUserName } from '@/lib/user-name';
 import { useQueryClient } from '@tanstack/react-query';
 import { agentKeys } from '@/hooks/react-query/agents/keys';
 import { normalizeFilenameToNFC } from '@/lib/utils/unicode';
@@ -317,7 +318,7 @@ export const AgentBuilderChat = React.memo(function AgentBuilderChat({
 
         const agentPromise = startAgentMutation.mutateAsync({
           threadId,
-          options
+          options: { ...options, user_name: getStoredUserName() || undefined }
         });
 
         const results = await Promise.allSettled([messagePromise, agentPromise]);

--- a/frontend/src/app/(dashboard)/agents/_components/agent-preview.tsx
+++ b/frontend/src/app/(dashboard)/agents/_components/agent-preview.tsx
@@ -15,6 +15,7 @@ import { useAddUserMessageMutation } from '@/hooks/react-query/threads/use-messa
 import { useStartAgentMutation, useStopAgentMutation } from '@/hooks/react-query/threads/use-agent-run';
 import { BillingError } from '@/lib/api';
 import { normalizeFilenameToNFC } from '@/lib/utils/unicode';
+import { getStoredUserName } from '@/lib/user-name';
 
 interface Agent {
   agent_id: string;
@@ -207,7 +208,7 @@ export const AgentPreview = ({ agent }: AgentPreviewProps) => {
           try {
             const agentResult = await startAgentMutation.mutateAsync({
               threadId: result.thread_id,
-              options
+              options: { ...options, user_name: getStoredUserName() || undefined }
             });
             console.log('[PREVIEW] Agent started manually:', agentResult);
             setAgentRunId(agentResult.agent_run_id);
@@ -274,7 +275,7 @@ export const AgentPreview = ({ agent }: AgentPreviewProps) => {
 
         const agentPromise = startAgentMutation.mutateAsync({
           threadId,
-          options
+          options: { ...options, user_name: getStoredUserName() || undefined }
         });
 
         const results = await Promise.allSettled([messagePromise, agentPromise]);

--- a/frontend/src/app/(dashboard)/projects/[projectId]/thread/[threadId]/page.tsx
+++ b/frontend/src/app/(dashboard)/projects/[projectId]/thread/[threadId]/page.tsx
@@ -18,6 +18,7 @@ import { useIsMobile } from '@/hooks/use-mobile';
 import { isLocalMode } from '@/lib/config';
 import { ThreadContent } from '@/components/thread/content/ThreadContent';
 import { ThreadSkeleton } from '@/components/thread/content/ThreadSkeleton';
+import { getStoredUserName } from '@/lib/user-name';
 import { useAddUserMessageMutation } from '@/hooks/react-query/threads/use-messages';
 import { useStartAgentMutation, useStopAgentMutation } from '@/hooks/react-query/threads/use-agent-run';
 import { useSubscription } from '@/hooks/react-query/subscriptions/use-subscriptions';
@@ -263,7 +264,7 @@ export default function ThreadPage({
 
         const agentPromise = startAgentMutation.mutateAsync({
           threadId,
-          options
+          options: { ...options, user_name: getStoredUserName() || undefined }
         });
 
         const results = await Promise.allSettled([messagePromise, agentPromise]);

--- a/frontend/src/components/basejump/edit-user-name.tsx
+++ b/frontend/src/components/basejump/edit-user-name.tsx
@@ -1,0 +1,42 @@
+'use client';
+
+import { Input } from '@/components/ui/input';
+import { SubmitButton } from '../ui/submit-button';
+import { Label } from '../ui/label';
+import { editUserName } from '@/lib/actions/user';
+
+type Props = {
+  currentName: string;
+};
+
+export default function EditUserName({ currentName }: Props) {
+  return (
+    <form className="animate-in space-y-4">
+      <div className="flex flex-col gap-y-2">
+        <Label
+          htmlFor="name"
+          className="text-sm font-medium text-foreground/90"
+        >
+          Your Name
+        </Label>
+        <Input
+          defaultValue={currentName}
+          name="name"
+          id="name"
+          placeholder="Pookie"
+          required
+          className="h-10 rounded-lg border-subtle dark:border-white/10 bg-white dark:bg-background-secondary"
+        />
+      </div>
+      <div className="flex justify-end">
+        <SubmitButton
+          formAction={editUserName}
+          pendingText="Updating..."
+          className="rounded-lg bg-primary hover:bg-primary/90 text-white h-10"
+        >
+          Save Changes
+        </SubmitButton>
+      </div>
+    </form>
+  );
+}

--- a/frontend/src/components/sidebar/nav-user-with-teams.tsx
+++ b/frontend/src/components/sidebar/nav-user-with-teams.tsx
@@ -264,16 +264,18 @@ export function NavUserWithTeams({
 
               <DropdownMenuSeparator />
               <DialogTrigger asChild>
-                <DropdownMenuItem 
+                <DropdownMenuItem
                   className="gap-2 p-2"
                   onClick={() => {
-                    setShowNewTeamDialog(true)
+                    setShowNewTeamDialog(true);
                   }}
                 >
                   <div className="bg-background flex size-6 items-center justify-center rounded-md border">
                     <Plus className="size-4" />
                   </div>
-                  <div className="text-muted-foreground font-medium">Add team</div>
+                  <div className="text-muted-foreground font-medium">
+                    Add team
+                  </div>
                 </DropdownMenuItem>
               </DialogTrigger>
               <DropdownMenuSeparator />
@@ -286,12 +288,12 @@ export function NavUserWithTeams({
                     Billing
                   </Link>
                 </DropdownMenuItem>
-                {/* <DropdownMenuItem asChild>
+                <DropdownMenuItem asChild>
                   <Link href="/settings">
                     <Settings className="mr-2 h-4 w-4" />
                     Settings
                   </Link>
-                </DropdownMenuItem> */}
+                </DropdownMenuItem>
                 <DropdownMenuItem
                   onClick={() => setTheme(theme === 'light' ? 'dark' : 'light')}
                 >
@@ -303,7 +305,10 @@ export function NavUserWithTeams({
                 </DropdownMenuItem>
               </DropdownMenuGroup>
               <DropdownMenuSeparator />
-              <DropdownMenuItem className='text-destructive focus:text-destructive focus:bg-destructive/10' onClick={handleLogout}>
+              <DropdownMenuItem
+                className="text-destructive focus:text-destructive focus:bg-destructive/10"
+                onClick={handleLogout}
+              >
                 <LogOut className="h-4 w-4 text-destructive" />
                 Log out
               </DropdownMenuItem>

--- a/frontend/src/hooks/react-query/threads/use-agent-run.ts
+++ b/frontend/src/hooks/react-query/threads/use-agent-run.ts
@@ -25,6 +25,7 @@ export const useStartAgentMutation = () =>
         reasoning_effort?: string;
         stream?: boolean;
         agent_id?: string;
+        user_name?: string;
       };
     }) => startAgent(threadId, options),
     {

--- a/frontend/src/lib/actions/user.ts
+++ b/frontend/src/lib/actions/user.ts
@@ -1,0 +1,16 @@
+'use server';
+
+import { createClient } from '../supabase/server';
+
+export async function editUserName(prevState: any, formData: FormData) {
+  const name = formData.get('name') as string;
+  const supabase = await createClient();
+
+  const { error } = await supabase.auth.updateUser({
+    data: { name },
+  });
+
+  if (error) {
+    return { message: error.message };
+  }
+}

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -555,6 +555,7 @@ export const startAgent = async (
     reasoning_effort?: string;
     stream?: boolean;
     agent_id?: string;
+    user_name?: string;
   },
 ): Promise<{ agent_run_id: string }> => {
   try {
@@ -584,6 +585,7 @@ export const startAgent = async (
       reasoning_effort: 'low',
       stream: true,
       agent_id: undefined,
+      user_name: undefined,
     };
 
     const finalOptions = { ...defaultOptions, ...options };
@@ -598,6 +600,9 @@ export const startAgent = async (
     // Only include agent_id if it's provided
     if (finalOptions.agent_id) {
       body.agent_id = finalOptions.agent_id;
+    }
+    if (finalOptions.user_name) {
+      body.user_name = finalOptions.user_name;
     }
 
     const response = await fetch(`${API_URL}/thread/${threadId}/agent/start`, {

--- a/frontend/src/lib/user-name.ts
+++ b/frontend/src/lib/user-name.ts
@@ -1,0 +1,11 @@
+export const USER_NAME_KEY = 'operatorUserName';
+
+export const getStoredUserName = (): string | null => {
+  if (typeof window === 'undefined') return null;
+  return localStorage.getItem(USER_NAME_KEY);
+};
+
+export const saveUserName = (name: string) => {
+  if (typeof window === 'undefined') return;
+  localStorage.setItem(USER_NAME_KEY, name);
+};


### PR DESCRIPTION
## Summary
- add helper for storing user name in localStorage
- include stored name when starting or initiating an agent
- personalize system prompt with user name

## Testing
- `npm run format:check`

------
https://chatgpt.com/codex/tasks/task_e_68617e77f1a08324bf37f37dc3678ac0