### PR TITLE
Add customization handling for agents

### DIFF
--- a/frontend/src/app/(dashboard)/agents/_components/agents-list.tsx
+++ b/frontend/src/app/(dashboard)/agents/_components/agents-list.tsx
@@ -14,6 +14,10 @@ interface Agent {
   updated_at?: string;
   configured_mcps?: Array<{ name: string }>;
   agentpress_tools?: Record<string, any>;
+  sharing_preferences?: {
+    disable_customization?: boolean;
+    [key: string]: any;
+  };
 }
 
 interface AgentsListProps {
@@ -56,7 +60,10 @@ export const AgentsList = ({
                     size="sm"
                     className="h-8 w-8 p-0"
                     onClick={() => onEditAgent(agent.agent_id)}
-                    title="Edit agent"
+                    disabled={agent.sharing_preferences?.disable_customization}
+                    title={agent.sharing_preferences?.disable_customization 
+                      ? "Customization is disabled by the creator" 
+                      : "Edit agent"}
                   >
                     <Settings className="h-4 w-4 text-muted-foreground" />
                   </Button>

--- a/frontend/src/app/(dashboard)/agents/new/[agentId]/page.tsx
+++ b/frontend/src/app/(dashboard)/agents/new/[agentId]/page.tsx
@@ -97,6 +97,15 @@ export default function AgentConfigurationPage() {
     }
   }, [error, router]);
 
+  // Check if customization is disabled for marketplace agents
+  useEffect(() => {
+    if (agent?.sharing_preferences?.disable_customization) {
+      toast.error('Customization is disabled by the creator. Talk to the creator of the agent for modifications.');
+      router.push('/agents');
+      return;
+    }
+  }, [agent, router]);
+
   useEffect(() => {
     currentFormDataRef.current = formData;
   }, [formData]);

--- a/frontend/src/app/(dashboard)/agents/page.tsx
+++ b/frontend/src/app/(dashboard)/agents/page.tsx
@@ -17,6 +17,7 @@ import { useRouter } from 'next/navigation';
 import { DEFAULT_AGENTPRESS_TOOLS } from './_data/tools';
 import { AgentsParams } from '@/hooks/react-query/agents/utils';
 import { useFeatureFlags } from '@/lib/feature-flags';
+import { toast } from 'sonner';
 
 type ViewMode = 'grid' | 'list';
 type SortOption = 'name' | 'created_at' | 'updated_at' | 'tools_count';
@@ -150,6 +151,11 @@ export default function AgentsPage() {
   };
 
   const handleEditAgent = (agentId: string) => {
+    const agent = agents.find(a => a.agent_id === agentId);
+    if (agent?.sharing_preferences?.disable_customization) {
+      toast.error('Customization is disabled by the creator. Talk to the creator of the agent for modifications.');
+      return;
+    }
     setEditingAgentId(agentId);
     setEditDialogOpen(true);
   };


### PR DESCRIPTION
- Implemented checks for agent customization preferences in the AgentsPage and AgentConfigurationPage components, displaying error messages when customization is disabled.
- Updated AgentsList component to disable the edit button and provide appropriate tooltips based on sharing preferences.
- Enhanced the sharing_preferences structure in the Agent type to support customization settings management.